### PR TITLE
Added support for BER decoding of indefinite length fields

### DIFF
--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -634,8 +634,8 @@ class MembersType(Type):
 
     def decode_member(self, member, data, values, offset, end_offset):
         try:
-            # If reached end of indefinite length field, decode should raise DecodeTagError,
-            # and end of field will be handled in .decode() method.
+            # If reached end of indefinite length field, member.decode will raise DecodeTagError,
+            # and end of field will be handled in MembersType.decode() method.
             if end_offset is None or offset < end_offset:
                 if isinstance(member, AnyDefinedBy):
                     value, offset = member.decode(data, offset, values)

--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -25,50 +25,50 @@ from .compiler import clean_bit_string_value
 
 
 class Class(object):
-    UNIVERSAL =         0x00
-    APPLICATION =       0x40
-    CONTEXT_SPECIFIC =  0x80
-    PRIVATE =           0xc0
+    UNIVERSAL           = 0x00
+    APPLICATION         = 0x40
+    CONTEXT_SPECIFIC    = 0x80
+    PRIVATE             = 0xc0
 
 
 class Encoding(object):
-    PRIMITIVE =     0x00
-    CONSTRUCTED =   0x20
+    PRIMITIVE           = 0x00
+    CONSTRUCTED         = 0x20
 
 
 class Tag(object):
-    END_OF_CONTENTS =   0x00
-    BOOLEAN =           0x01
-    INTEGER =           0x02
-    BIT_STRING =        0x03
-    OCTET_STRING =      0x04
-    NULL =              0x05
-    OBJECT_IDENTIFIER = 0x06
-    OBJECT_DESCRIPTOR = 0x07
-    EXTERNAL =          0x08
-    REAL =              0x09
-    ENUMERATED =        0x0a
-    EMBEDDED_PDV =      0x0b
-    UTF8_STRING =       0x0c
-    RELATIVE_OID =      0x0d
-    SEQUENCE =          0x10
-    SET =               0x11
-    NUMERIC_STRING =    0x12
-    PRINTABLE_STRING =  0x13
-    T61_STRING =        0x14
-    VIDEOTEX_STRING =   0x15
-    IA5_STRING =        0x16
-    UTC_TIME =          0x17
-    GENERALIZED_TIME =  0x18
-    GRAPHIC_STRING =    0x19
-    VISIBLE_STRING =    0x1a
-    GENERAL_STRING =    0x1b
-    UNIVERSAL_STRING =  0x1c
-    CHARACTER_STRING =  0x1d
-    BMP_STRING =        0x1e
-    DATE =              0x1f
-    TIME_OF_DAY =       0x20
-    DATE_TIME =         0x21
+    END_OF_CONTENTS     = 0x00
+    BOOLEAN             = 0x01
+    INTEGER             = 0x02
+    BIT_STRING          = 0x03
+    OCTET_STRING        = 0x04
+    NULL                = 0x05
+    OBJECT_IDENTIFIER   = 0x06
+    OBJECT_DESCRIPTOR   = 0x07
+    EXTERNAL            = 0x08
+    REAL                = 0x09
+    ENUMERATED          = 0x0a
+    EMBEDDED_PDV        = 0x0b
+    UTF8_STRING         = 0x0c
+    RELATIVE_OID        = 0x0d
+    SEQUENCE            = 0x10
+    SET                 = 0x11
+    NUMERIC_STRING      = 0x12
+    PRINTABLE_STRING    = 0x13
+    T61_STRING          = 0x14
+    VIDEOTEX_STRING     = 0x15
+    IA5_STRING          = 0x16
+    UTC_TIME            = 0x17
+    GENERALIZED_TIME    = 0x18
+    GRAPHIC_STRING      = 0x19
+    VISIBLE_STRING      = 0x1a
+    GENERAL_STRING      = 0x1b
+    UNIVERSAL_STRING    = 0x1c
+    CHARACTER_STRING    = 0x1d
+    BMP_STRING          = 0x1e
+    DATE                = 0x1f
+    TIME_OF_DAY         = 0x20
+    DATE_TIME           = 0x21
 
 
 EOC_TAG = bytes(2)

--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -25,50 +25,50 @@ from .compiler import clean_bit_string_value
 
 
 class Class(object):
-    UNIVERSAL           = 0x00
-    APPLICATION         = 0x40
-    CONTEXT_SPECIFIC    = 0x80
-    PRIVATE             = 0xc0
+    UNIVERSAL        = 0x00
+    APPLICATION      = 0x40
+    CONTEXT_SPECIFIC = 0x80
+    PRIVATE          = 0xc0
 
 
 class Encoding(object):
-    PRIMITIVE           = 0x00
-    CONSTRUCTED         = 0x20
+    PRIMITIVE   = 0x00
+    CONSTRUCTED = 0x20
 
 
 class Tag(object):
-    END_OF_CONTENTS     = 0x00
-    BOOLEAN             = 0x01
-    INTEGER             = 0x02
-    BIT_STRING          = 0x03
-    OCTET_STRING        = 0x04
-    NULL                = 0x05
-    OBJECT_IDENTIFIER   = 0x06
-    OBJECT_DESCRIPTOR   = 0x07
-    EXTERNAL            = 0x08
-    REAL                = 0x09
-    ENUMERATED          = 0x0a
-    EMBEDDED_PDV        = 0x0b
-    UTF8_STRING         = 0x0c
-    RELATIVE_OID        = 0x0d
-    SEQUENCE            = 0x10
-    SET                 = 0x11
-    NUMERIC_STRING      = 0x12
-    PRINTABLE_STRING    = 0x13
-    T61_STRING          = 0x14
-    VIDEOTEX_STRING     = 0x15
-    IA5_STRING          = 0x16
-    UTC_TIME            = 0x17
-    GENERALIZED_TIME    = 0x18
-    GRAPHIC_STRING      = 0x19
-    VISIBLE_STRING      = 0x1a
-    GENERAL_STRING      = 0x1b
-    UNIVERSAL_STRING    = 0x1c
-    CHARACTER_STRING    = 0x1d
-    BMP_STRING          = 0x1e
-    DATE                = 0x1f
-    TIME_OF_DAY         = 0x20
-    DATE_TIME           = 0x21
+    END_OF_CONTENTS   = 0x00
+    BOOLEAN           = 0x01
+    INTEGER           = 0x02
+    BIT_STRING        = 0x03
+    OCTET_STRING      = 0x04
+    NULL              = 0x05
+    OBJECT_IDENTIFIER = 0x06
+    OBJECT_DESCRIPTOR = 0x07
+    EXTERNAL          = 0x08
+    REAL              = 0x09
+    ENUMERATED        = 0x0a
+    EMBEDDED_PDV      = 0x0b
+    UTF8_STRING       = 0x0c
+    RELATIVE_OID      = 0x0d
+    SEQUENCE          = 0x10
+    SET               = 0x11
+    NUMERIC_STRING    = 0x12
+    PRINTABLE_STRING  = 0x13
+    T61_STRING        = 0x14
+    VIDEOTEX_STRING   = 0x15
+    IA5_STRING        = 0x16
+    UTC_TIME          = 0x17
+    GENERALIZED_TIME  = 0x18
+    GRAPHIC_STRING    = 0x19
+    VISIBLE_STRING    = 0x1a
+    GENERAL_STRING    = 0x1b
+    UNIVERSAL_STRING  = 0x1c
+    CHARACTER_STRING  = 0x1d
+    BMP_STRING        = 0x1e
+    DATE              = 0x1f
+    TIME_OF_DAY       = 0x20
+    DATE_TIME         = 0x21
 
 
 EOC_TAG = bytes(2)
@@ -454,7 +454,7 @@ class PrimitiveOrConstructedType(Type):
             segments = []
 
             if length is None:
-                while data[offset:offset + 2] != b'\x00\x00':
+                while data[offset:offset + 2] != EOC_TAG:
                     decoded, offset = self.segment.decode(data, offset)
                     segments.append(decoded)
 
@@ -598,8 +598,11 @@ class MembersType(Type):
                                            offset,
                                            end_offset)
         # Detect end of indefinite length constructed field
-        if end_offset is None and data[offset:offset + 2] == EOC_TAG:
-            end_offset = offset + 2
+        if end_offset is None:
+            if data[offset:offset + 2] == EOC_TAG:
+                end_offset = offset + 2
+            else:
+                raise DecodeError('Could not find end-of-contents tag for indefinite length field')
 
         return values, end_offset
 
@@ -1121,56 +1124,67 @@ class Choice(Type):
 
 
 class UTF8String(StringType):
+
     TAG = Tag.UTF8_STRING
     ENCODING = 'utf-8'
 
 
 class NumericString(StringType):
+
     TAG = Tag.NUMERIC_STRING
     ENCODING = 'ascii'
 
 
 class PrintableString(StringType):
+
     TAG = Tag.PRINTABLE_STRING
     ENCODING = 'ascii'
 
 
 class IA5String(StringType):
+
     TAG = Tag.IA5_STRING
     ENCODING = 'ascii'
 
 
 class VisibleString(StringType):
+
     TAG = Tag.VISIBLE_STRING
     ENCODING = 'ascii'
 
 
 class GeneralString(StringType):
+
     TAG = Tag.GENERAL_STRING
     ENCODING = 'latin-1'
 
 
 class BMPString(StringType):
+
     TAG = Tag.BMP_STRING
     ENCODING = 'utf-16-be'
 
 
 class GraphicString(StringType):
+
     TAG = Tag.GRAPHIC_STRING
     ENCODING = 'latin-1'
 
 
 class UniversalString(StringType):
+
     TAG = Tag.UNIVERSAL_STRING
     ENCODING = 'utf-32-be'
 
 
 class TeletexString(StringType):
+
     TAG = Tag.T61_STRING
     ENCODING = 'iso-8859-1'
 
 
 class ObjectDescriptor(GraphicString):
+
     TAG = Tag.OBJECT_DESCRIPTOR
 
 

--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -1417,6 +1417,8 @@ class ExplicitTag(Type):
 
         values, end_offset = self.inner.decode(data, offset)
         if indefinite:
+            if data[end_offset:end_offset+2] != EOC_TAG:
+                raise DecodeError('Expected End-Of-Contents tag at offset: {}'.format(end_offset))
             end_offset += 2
         return values, end_offset
 

--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -71,7 +71,7 @@ class Tag(object):
     DATE_TIME         = 0x21
 
 
-END_OF_CONTENTS_OCTETS = bytes(2)
+END_OF_CONTENTS_OCTETS = b'\x00\x00'
 
 
 class DecodeChoiceError(Error):

--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -476,6 +476,7 @@ class PrimitiveOrConstructedType(Type):
 
 
 class StringType(PrimitiveOrConstructedType):
+
     TAG = None
     ENCODING = None
 
@@ -572,10 +573,9 @@ class MembersType(Type):
         offset = self.decode_tag(data, offset)
 
         if data[offset] == 0x80:
-            # Indefinite length field
-            offset = offset + 1
+            # Indefinite length field.
+            offset += 1
             end_offset = None
-            # raise NotImplementedError('Decode until an end-of-contents tag is not yet implemented.')
         else:
             # Definite length field
             length, offset = decode_length_definite(data, offset)
@@ -585,7 +585,7 @@ class MembersType(Type):
 
         for member in self.root_members:
             # End of indefinite length sequence may be reached at any time, but DecodeError will occur
-            # (instead of usual IndexError) and so further members will be skipped
+            # (instead of usual IndexError) and so further members will be skipped.
             offset = self.decode_member(member,
                                         data,
                                         values,
@@ -597,12 +597,13 @@ class MembersType(Type):
                                            values,
                                            offset,
                                            end_offset)
-        # Detect end of indefinite length constructed field
+
+        # Detect end of indefinite length constructed field.
         if end_offset is None:
             if data[offset:offset + 2] == EOC_TAG:
                 end_offset = offset + 2
             else:
-                raise DecodeError('Could not find end-of-contents tag for indefinite length field')
+                raise DecodeError('Could not find end-of-contents tag for indefinite length field.')
 
         return values, end_offset
 
@@ -628,12 +629,13 @@ class MembersType(Type):
                 values.update(addition_values)
         except DecodeError:
             pass
+
         return offset
 
     def decode_member(self, member, data, values, offset, end_offset):
         try:
             # If reached end of indefinite length field, decode should raise DecodeTagError,
-            # and end of field will be handled in .decode() method
+            # and end of field will be handled in .decode() method.
             if end_offset is None or offset < end_offset:
                 if isinstance(member, AnyDefinedBy):
                     value, offset = member.decode(data, offset, values)
@@ -641,7 +643,6 @@ class MembersType(Type):
                     value, offset = member.decode(data, offset)
             else:
                 raise IndexError
-
         except (DecodeError, DecodeTagError, IndexError) as e:
             if member.optional:
                 return offset
@@ -692,23 +693,22 @@ class ArrayType(Type):
     def decode(self, data, offset):
         offset = self.decode_tag(data, offset)
         if data[offset] == 0x80:
-            offset = offset + 1
-            length = None  # Indicates indefinite field
-            # raise NotImplementedError('Decode until an end-of-contents tag is not yet implemented.')
+            offset += 1
+            length = None  # Indicates indefinite field.
         else:
             length, offset = decode_length_definite(data, offset)
 
         decoded = []
         start_offset = offset
-        # Loop through data until length exceeded or end-of-contents tag reached
-        while 1:
+        # Loop through data until length exceeded or end-of-contents tag reached.
+        while True:
             if length is None:
-                # Find end of indefinite sequence
+                # Find end of indefinite sequence.
                 if data[offset:offset + 2] == EOC_TAG:
                     offset += 2
                     break
             elif (offset - start_offset) >= length:
-                # End of definite length sequence
+                # End of definite length sequence.
                 break
             decoded_element, offset = self.element_type.decode(data, offset)
             decoded.append(decoded_element)
@@ -1407,19 +1407,22 @@ class ExplicitTag(Type):
     def decode(self, data, offset):
         offset = self.decode_tag(data, offset)
         indefinite = False
+
         if data[offset] == 0x80:
             # Indefinite length field
-            offset = offset + 1
+            offset += 1
             indefinite = True
         else:
             # Definite length field
             length, offset = decode_length_definite(data, offset)
 
         values, end_offset = self.inner.decode(data, offset)
+
         if indefinite:
-            if data[end_offset:end_offset+2] != EOC_TAG:
-                raise DecodeError('Expected End-Of-Contents tag at offset: {}'.format(end_offset))
+            if data[end_offset:end_offset + 2] != EOC_TAG:
+                raise DecodeError('Expected end-of-contents tag at offset: {}.'.format(end_offset))
             end_offset += 2
+
         return values, end_offset
 
     def __repr__(self):

--- a/asn1tools/codecs/compiler.py
+++ b/asn1tools/codecs/compiler.py
@@ -83,15 +83,32 @@ def clean_bit_string_value(value, has_named_bits):
 
 class CompiledType(object):
 
-    def __init__(self):
+    def __init__(self, type_):
         self.constraints_checker = None
         self.type_checker = None
+        self._type = type_
+
+    @property
+    def type(self):
+        return self._type
 
     def check_types(self, data):
         return self.type_checker.encode(data)
 
     def check_constraints(self, data):
         return self.constraints_checker.encode(data)
+
+    def encode(self, data):
+        raise NotImplementedError('This codec does not support encode().')
+
+    def decode(self, data):
+        raise NotImplementedError('This codec does not support decode().')
+
+    def decode_with_length(self, data):
+        raise NotImplementedError('This codec does not support decode_with_length().')
+
+    def __repr__(self):
+        return repr(self._type)
 
 
 class Recursive(object):
@@ -140,26 +157,23 @@ class OpenTypeSequenceOf(object):
 class CompiledOpenTypes(CompiledType):
 
     def __init__(self, compiled_open_types, compiled_type):
-        super(CompiledOpenTypes, self).__init__()
+        super(CompiledOpenTypes, self).__init__(compiled_type)
         self._compiled_open_types = compiled_open_types
-        self._inner = compiled_type
 
     @property
     def type(self):
-        return self._inner.type
+        return self._type.type
 
     def encode(self, data, **kwargs):
         # print()
         # print('data:', data)
         # print(self._compiled_open_types)
 
-        return self._inner.encode(data, **kwargs)
+        return self._type.encode(data, **kwargs)
 
     def decode(self, data):
-        return self._inner.decode(data)
+        return self._type.decode(data)
 
-    def __repr__(self):
-        return repr(self._inner)
 
 
 class Compiler(object):

--- a/asn1tools/codecs/constraints_checker.py
+++ b/asn1tools/codecs/constraints_checker.py
@@ -327,14 +327,6 @@ class Recursive(Type, compiler.Recursive):
 
 class CompiledType(compiler.CompiledType):
 
-    def __init__(self, type_):
-        super(CompiledType, self).__init__()
-        self._type = type_
-
-    @property
-    def type(self):
-        return self._type
-
     def encode(self, data):
         self._type.encode(data)
 

--- a/asn1tools/codecs/gser.py
+++ b/asn1tools/codecs/gser.py
@@ -499,14 +499,9 @@ class Recursive(Type, compiler.Recursive):
 class CompiledType(compiler.CompiledType):
 
     def __init__(self, type_name, compiled_type):
-        super(CompiledType, self).__init__()
+        super(CompiledType, self).__init__(compiled_type)
         self._value_name = type_name.lower()
         self._value_type = type_name
-        self._type = compiled_type
-
-    @property
-    def type(self):
-        return self._type
 
     def encode(self, data, indent=None):
         if indent is None:
@@ -522,9 +517,6 @@ class CompiledType(compiler.CompiledType):
 
     def decode(self, data):
         raise NotImplementedError('GSER decoding is not implemented.')
-
-    def __repr__(self):
-        return repr(self._type)
 
 
 class Compiler(compiler.Compiler):

--- a/asn1tools/codecs/jer.py
+++ b/asn1tools/codecs/jer.py
@@ -541,14 +541,6 @@ class Recursive(Type, compiler.Recursive):
 
 class CompiledType(compiler.CompiledType):
 
-    def __init__(self, type_):
-        super(CompiledType, self).__init__()
-        self._type = type_
-
-    @property
-    def type(self):
-        return self._type
-
     def encode(self, data, indent=None):
         dictionary = self._type.encode(data)
 
@@ -561,9 +553,6 @@ class CompiledType(compiler.CompiledType):
 
     def decode(self, data):
         return self._type.decode(json.loads(data.decode('utf-8')))
-
-    def __repr__(self):
-        return repr(self._type)
 
 
 class Compiler(compiler.Compiler):

--- a/asn1tools/codecs/oer.py
+++ b/asn1tools/codecs/oer.py
@@ -1288,14 +1288,6 @@ class Recursive(Type, compiler.Recursive):
 
 class CompiledType(compiler.CompiledType):
 
-    def __init__(self, type_):
-        super(CompiledType, self).__init__()
-        self._type = type_
-
-    @property
-    def type(self):
-        return self._type
-
     def encode(self, data):
         encoder = Encoder()
         self._type.encode(data, encoder)
@@ -1306,9 +1298,6 @@ class CompiledType(compiler.CompiledType):
         decoder = Decoder(bytearray(data))
 
         return self._type.decode(decoder)
-
-    def __repr__(self):
-        return repr(self._type)
 
 
 class Compiler(compiler.Compiler):

--- a/asn1tools/codecs/per.py
+++ b/asn1tools/codecs/per.py
@@ -2027,14 +2027,6 @@ class AdditionGroup(Sequence):
 
 class CompiledType(compiler.CompiledType):
 
-    def __init__(self, type_):
-        super(CompiledType, self).__init__()
-        self._type = type_
-
-    @property
-    def type(self):
-        return self._type
-
     def encode(self, data):
         encoder = Encoder()
         self._type.encode(data, encoder)
@@ -2045,9 +2037,6 @@ class CompiledType(compiler.CompiledType):
         decoder = Decoder(bytearray(data))
 
         return self._type.decode(decoder)
-
-    def __repr__(self):
-        return repr(self._type)
 
 
 class Compiler(compiler.Compiler):

--- a/asn1tools/codecs/type_checker.py
+++ b/asn1tools/codecs/type_checker.py
@@ -292,14 +292,6 @@ class Recursive(Type, compiler.Recursive):
 
 class CompiledType(compiler.CompiledType):
 
-    def __init__(self, type_):
-        super(CompiledType, self).__init__()
-        self._type = type_
-
-    @property
-    def type(self):
-        return self._type
-
     def encode(self, data):
         self._type.encode(data)
 

--- a/asn1tools/codecs/uper.py
+++ b/asn1tools/codecs/uper.py
@@ -22,7 +22,6 @@ from .per import Sequence
 from .per import Set
 from .per import UTF8String
 from .per import GeneralString
-from .per import BMPString
 from .per import GraphicString
 from .per import TeletexString
 from .per import UniversalString

--- a/asn1tools/codecs/xer.py
+++ b/asn1tools/codecs/xer.py
@@ -679,14 +679,6 @@ class Recursive(Type, compiler.Recursive):
 
 class CompiledType(compiler.CompiledType):
 
-    def __init__(self, type_):
-        super(CompiledType, self).__init__()
-        self._type = type_
-
-    @property
-    def type(self):
-        return self._type
-
     def encode(self, data, indent=None):
         element = self._type.encode(data)
 
@@ -699,9 +691,6 @@ class CompiledType(compiler.CompiledType):
         element = ElementTree.fromstring(data.decode('utf-8'))
 
         return self._type.decode(element)
-
-    def __repr__(self):
-        return repr(self._type)
 
 
 class Compiler(compiler.Compiler):

--- a/asn1tools/compiler.py
+++ b/asn1tools/compiler.py
@@ -171,6 +171,8 @@ class Specification(object):
         """Decode given bytes object `data` as given type `name` and return
         the decoded data as a dictionary, along with byte length of the data.
 
+        Use to get length of indefinite-length BER encoded data.
+
         If `check_constraints` is ``True`` all objects in `data` are
         checked against their ASN.1 type constraints. A
         ConstraintsError exception is raised if the constraints are

--- a/asn1tools/compiler.py
+++ b/asn1tools/compiler.py
@@ -168,19 +168,10 @@ class Specification(object):
         return decoded
 
     def decode_with_length(self, name, data, check_constraints=False):
-        """Decode given bytes object `data` as given type `name` and return
-        the decoded data as a dictionary, along with byte length of the data.
+        """Same as :func:`~asn1tools.compiler.Specification.decode`,
+        but also returns the byte length of the decoded data.
 
-        Use to get length of indefinite-length BER encoded data.
-        Only works for BER or DER codec
-
-        If `check_constraints` is ``True`` all objects in `data` are
-        checked against their ASN.1 type constraints. A
-        ConstraintsError exception is raised if the constraints are
-        not fulfilled. Set `check_constraints` to ``False`` to skip
-        the constraints check and minimize the runtime overhead, but
-        instead allow decoding of values not fulfilling the
-        constraints.
+        Use to get the length of indefinite-length BER encoded data.
 
         >>> foo.decode_with_length('Question', b'0\\x0e\\x02\\x01\\x01\\x16\\x09Is 1+1=3?')
         ({'id': 1, 'question': 'Is 1+1=3?'}, 16)
@@ -192,9 +183,6 @@ class Specification(object):
         except KeyError:
             raise DecodeError(
                 "Type '{}' not found in types dictionary.".format(name))
-
-        if not hasattr(type_, 'decode_with_length'):
-            raise DecodeError("Type '{}' does not support decode_with_length".format(name))
 
         decoded, length = type_.decode_with_length(data)
 

--- a/asn1tools/compiler.py
+++ b/asn1tools/compiler.py
@@ -172,6 +172,7 @@ class Specification(object):
         the decoded data as a dictionary, along with byte length of the data.
 
         Use to get length of indefinite-length BER encoded data.
+        Only works for BER or DER codec
 
         If `check_constraints` is ``True`` all objects in `data` are
         checked against their ASN.1 type constraints. A
@@ -181,8 +182,8 @@ class Specification(object):
         instead allow decoding of values not fulfilling the
         constraints.
 
-        >>> foo.decode('Question', b'0\\x0e\\x02\\x01\\x01\\x16\\x09Is 1+1=3?')
-        {'id': 1, 'question': 'Is 1+1=3?'}
+        >>> foo.decode_with_length('Question', b'0\\x0e\\x02\\x01\\x01\\x16\\x09Is 1+1=3?')
+        ({'id': 1, 'question': 'Is 1+1=3?'}, 16)
 
         """
 

--- a/tests/test_ber.py
+++ b/tests/test_ber.py
@@ -669,7 +669,7 @@ class Asn1ToolsBerTest(Asn1ToolsBaseTest):
 
         self.assertEqual(
             str(cm.exception),
-            'Could not find end-of-contents tag for indefinite length field')
+            'Could not find end-of-contents tag for indefinite length field.')
 
         # Missing member.
         with self.assertRaises(asn1tools.EncodeError) as cm:
@@ -728,14 +728,15 @@ class Asn1ToolsBerTest(Asn1ToolsBaseTest):
 
         # Test indefinite length set with end-of-contents tags
         self.assertEqual(foo.decode('A', b'\x31\x80\x80\x01\x03\x81\x01\x00\x00\x00'), {'a': 3, 'b': 0})
-        self.assertEqual(foo.decode('C', b'\x31\x80\xa0\x80\x80\x01\x03\x81\x01\x04\x00\x00\x81\x01\x12\x00\x00'), {'a': {'a': 3, 'b': 4}, 'b': b'\x12'})
+        self.assertEqual(foo.decode('C', b'\x31\x80\xa0\x80\x80\x01\x03\x81\x01\x04\x00\x00\x81\x01\x12\x00\x00'),
+                         {'a': {'a': 3, 'b': 4}, 'b': b'\x12'})
         # Test error when EOC tag is missing
         with self.assertRaises(asn1tools.DecodeError) as cm:
             foo.decode('C', b'\x31\x80\xa0\x80\x80\x01\x03\x81\x01\x04\x81\x01\x12\x00\x00')
 
         self.assertEqual(
             str(cm.exception),
-            'a: Could not find end-of-contents tag for indefinite length field')
+            'a: Could not find end-of-contents tag for indefinite length field.')
 
     def test_choice(self):
         foo = asn1tools.compile_string(

--- a/tests/test_gser.py
+++ b/tests/test_gser.py
@@ -932,6 +932,19 @@ class Asn1ToolsGserTest(Asn1ToolsBaseTest):
         self.assertEqual(rfc4511.encode('LDAPMessage', decoded, indent=2),
                          encoded)
 
+    def test_not_support_decode_with_length(self):
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS AUTOMATIC TAGS ::= "
+            "BEGIN "
+            "A ::= OCTET STRING "
+            "END",
+            'gser')
+
+        with self.assertRaises(NotImplementedError) as cm:
+            foo.decode_with_length('A', b'\x01\x23\x45\x67\x89\xab\xcd\xef')
+
+        self.assertEqual(str(cm.exception), "This codec does not support decode_with_length().")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_jer.py
+++ b/tests/test_jer.py
@@ -866,6 +866,19 @@ class Asn1ToolsJerTest(unittest.TestCase):
             for line in encoded.splitlines():
                 self.assertIn(line, encoded_lines)
 
+    def test_not_support_decode_with_length(self):
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS AUTOMATIC TAGS ::= "
+            "BEGIN "
+            "A ::= OCTET STRING "
+            "END",
+            'jer')
+
+        with self.assertRaises(NotImplementedError) as cm:
+            foo.decode_with_length('A', b'\x01\x23\x45\x67\x89\xab\xcd\xef')
+
+        self.assertEqual(str(cm.exception), "This codec does not support decode_with_length().")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_oer.py
+++ b/tests/test_oer.py
@@ -1006,6 +1006,19 @@ class Asn1ToolsOerTest(Asn1ToolsBaseTest):
         with self.assertRaises(asn1tools.codecs.OutOfDataError):
             foo.decode('L', b'\xff\x00')
 
+    def test_not_support_decode_with_length(self):
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS AUTOMATIC TAGS ::= "
+            "BEGIN "
+            "A ::= OCTET STRING "
+            "END",
+            'oer')
+
+        with self.assertRaises(NotImplementedError) as cm:
+            foo.decode_with_length('A', b'\x01\x23\x45\x67\x89\xab\xcd\xef')
+
+        self.assertEqual(str(cm.exception), "This codec does not support decode_with_length().")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_per.py
+++ b/tests/test_per.py
@@ -2203,6 +2203,19 @@ class Asn1ToolsPerTest(Asn1ToolsBaseTest):
 
         self.assert_encode_decode(ulp, 'ULP-PDU', decoded, encoded)
 
+    def test_not_support_decode_with_length(self):
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS AUTOMATIC TAGS ::= "
+            "BEGIN "
+            "A ::= OCTET STRING "
+            "END",
+            'oer')
+
+        with self.assertRaises(NotImplementedError) as cm:
+            foo.decode_with_length('A', b'\x01\x23\x45\x67\x89\xab\xcd\xef')
+
+        self.assertEqual(str(cm.exception), "This codec does not support decode_with_length().")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_uper.py
+++ b/tests/test_uper.py
@@ -2669,6 +2669,19 @@ class Asn1ToolsUPerTest(Asn1ToolsBaseTest):
 
         self.assert_encode_decode(ulp, 'ULP-PDU', decoded, encoded)
 
+    def test_not_support_decode_with_length(self):
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS AUTOMATIC TAGS ::= "
+            "BEGIN "
+            "A ::= OCTET STRING "
+            "END",
+            'uper')
+
+        with self.assertRaises(NotImplementedError) as cm:
+            foo.decode_with_length('A', b'\x01\x23\x45\x67\x89\xab\xcd\xef')
+
+        self.assertEqual(str(cm.exception), "This codec does not support decode_with_length().")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_xer.py
+++ b/tests/test_xer.py
@@ -954,6 +954,19 @@ class Asn1ToolsXerTest(Asn1ToolsBaseTest):
                                          decoded,
                                          encoded)
 
+    def test_not_support_decode_with_length(self):
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS AUTOMATIC TAGS ::= "
+            "BEGIN "
+            "A ::= OCTET STRING "
+            "END",
+            'xer')
+
+        with self.assertRaises(NotImplementedError) as cm:
+            foo.decode_with_length('A', b'\x01\x23\x45\x67\x89\xab\xcd\xef')
+
+        self.assertEqual(str(cm.exception), "This codec does not support decode_with_length().")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A project I'm working on requires decoding of indefinite-length fields for BER encoding. 
I made required changes to support it and appears to be working well.
Added Specification.decode_with_length() method which returns decoded data and byte length, useful for indefinite-length decoding.
Tested with indefinite length Sets and Sequences