### PR TITLE
Allow comma decimal separator in BER encoding of real numbers

### DIFF
--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -297,7 +297,7 @@ def decode_real_special(control):
 
 
 def decode_real_decimal(data):
-    return float(data[1:])
+    return float(data[1:].replace(b',', b'.'))
 
 
 def decode_real(data):

--- a/tests/test_ber.py
+++ b/tests/test_ber.py
@@ -214,6 +214,9 @@ class Asn1ToolsBerTest(Asn1ToolsBaseTest):
         # Decode 100.0 in decimal form (1.e2).
         self.assertEqual(foo.decode('A', b'\x09\x05\x03\x31\x2e\x45\x32'),
                          100.0)
+        # Decode 100.0 in decimal form with comma (100,0).
+        self.assertEqual(foo.decode('A', b'\x09\x06\x02\x31\x30\x30\x2c\x30'),
+                         100.0)
 
     def test_bit_string(self):
         foo = asn1tools.compile_string(


### PR DESCRIPTION
Added support for comma in BER encoding of real numbers, which we are missing. The UTI-T X.690 standard states in p.8.5.8 that encoding of real numbers is defined by ISO 6093, which allows two decimal marks: comma and period.