### PR TITLE
Preprocess OCTET STRING default value

### DIFF
--- a/asn1tools/codecs/compiler.py
+++ b/asn1tools/codecs/compiler.py
@@ -2,6 +2,8 @@
 
 """
 
+import binascii
+import sys
 from operator import attrgetter
 import bitstruct
 
@@ -441,6 +443,9 @@ class Compiler(object):
                     self.pre_process_default_value_bit_string(member,
                                                               resolved_member)
 
+                if resolved_member['type'] == 'OCTET STRING':
+                    self.pre_process_default_value_octet_string(member)
+
                 if resolved_member['type'] == 'ENUMERATED' and self._numeric_enums:
                     for key, value in resolved_member['values']:
                         if key == member['default']:
@@ -483,6 +488,19 @@ class Compiler(object):
             mask = b''
 
         member['default'] = (mask, number_of_bits)
+
+    def pre_process_default_value_octet_string(self, member):
+        default = member['default']
+
+        if sys.version_info[0] > 2 and isinstance(default, bytes):
+            # Already pre-processed.
+            return
+
+        if default.startswith('0b'):
+            default = hex(int(default, 2))
+
+        if default.startswith('0x'):
+            member['default'] = binascii.unhexlify(default[2:])
 
     def pre_process_parameterization_step_1(self, types, module_name):
         """X.683 parameterization pre processing - step 1.

--- a/asn1tools/codecs/compiler.py
+++ b/asn1tools/codecs/compiler.py
@@ -500,7 +500,10 @@ class Compiler(object):
             default = hex(int(default, 2))
 
         if default.startswith('0x'):
-            member['default'] = binascii.unhexlify(default[2:])
+            default = default[2:]
+            if len(default) % 2 == 1:
+                default = '0' + default
+            member['default'] = binascii.unhexlify(default)
 
     def pre_process_parameterization_step_1(self, types, module_name):
         """X.683 parameterization pre processing - step 1.

--- a/tests/test_der.py
+++ b/tests/test_der.py
@@ -154,6 +154,34 @@ class Asn1ToolsDerTest(Asn1ToolsBaseTest):
             self.assertEqual(foo.encode(type_name, decoded_1), encoded)
             self.assertEqual(foo.decode(type_name, encoded), decoded_2)
 
+    def test_octet_string(self):
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS AUTOMATIC TAGS ::= "
+            "BEGIN "
+            "A ::= SEQUENCE { "
+            "  b OCTET STRING DEFAULT '011'B, "
+            "  c OCTET STRING DEFAULT '60'H "
+            "} "
+            "END",
+            'der')
+
+        datas = [
+            ('A', {'b': b'\xcc', 'c': b'\xdd'}, b'\x30\x06\x80\x01\xcc\x81\x01\xdd'),
+        ]
+
+        for type_name, decoded, encoded in datas:
+            self.assert_encode_decode(foo, type_name, decoded, encoded)
+
+        # Default value is not encoded, but part of decoded.
+        datas = [
+            ('A', {}, b'\x30\x00', {'b': b'\x03', 'c': b'\x60'}),
+            ('A', {'b': b'\xcc'}, b'\x30\x03\x80\x01\xcc', {'b': b'\xcc', 'c': b'\x60'}),
+        ]
+
+        for type_name, decoded_1, encoded, decoded_2 in datas:
+            self.assertEqual(foo.encode(type_name, decoded_1), encoded)
+            self.assertEqual(foo.decode(type_name, encoded), decoded_2)
+
     def test_set(self):
         foo = asn1tools.compile_string(
             "Foo DEFINITIONS IMPLICIT TAGS ::= "


### PR DESCRIPTION
The default values of `OCTET STRING` fields parsed from `pyparsing` need to be preprocessed before using.

Sample code to trigger the bug:

```python
import asn1tools
tags = asn1tools.compile_string('''\
MyDef DEFINITIONS AUTOMATIC TAGS ::= BEGIN

MySeq ::= SEQUENCE {
    field [10] OCTET STRING (SIZE (1)) DEFAULT '05'H
}

END
''', 'der')
t1 = tags.encode('MySeq', {})
print(t1)
t2 = tags.decode('MySeq', t1)
print(t2)
t3 = tags.encode('MySeq', t2)
print(t3)
```

Output before applying this patch:

```
bytearray(b'0\x00')
{'field': '0x05'}
Traceback (most recent call last):
  File "/path/to/sample.py", line 15, in <module>
    t3 = tags.encode('MySeq', t2)
  File "/path/to/asn1tools/compiler.py", line 133, in encode
    type_.check_types(data)
  File "/path/to/asn1tools/codecs/compiler.py", line 102, in check_types
    return self.type_checker.encode(data)
  File "/path/to/asn1tools/codecs/type_checker.py", line 308, in encode
    self._type.encode(data)
  File "/path/to/asn1tools/codecs/type_checker.py", line 150, in encode
    self.encode_members(data)
  File "/path/to/asn1tools/codecs/__init__.py", line 168, in new_method
    raise e
  File "/path/to/asn1tools/codecs/__init__.py", line 163, in new_method
    return method(self, *args, **kwargs)
  File "/path/to/asn1tools/codecs/type_checker.py", line 158, in encode_members
    member.encode(data[name])
  File "/path/to/asn1tools/codecs/__init__.py", line 168, in new_method
    raise e
  File "/path/to/asn1tools/codecs/__init__.py", line 163, in new_method
    return method(self, *args, **kwargs)
  File "/path/to/asn1tools/codecs/type_checker.py", line 121, in encode
    raise EncodeError(
asn1tools.codecs.EncodeError: MySeq.field: Expected data of type bytes or bytearray, but got 0x05.
```

Output after applying this patch:

```
bytearray(b'0\x00')
{'field': b'\x05'}
bytearray(b'0\x00')
```