### PR TITLE
Follow up for PR #112

### DIFF
--- a/asn1tools/codecs/compiler.py
+++ b/asn1tools/codecs/compiler.py
@@ -477,6 +477,8 @@ class Compiler(object):
             mask >>= lowest_set_bit(mask)
             number_of_bits = mask.bit_length() - 1
             mask ^= (1 << number_of_bits)
+        elif default == '0b':
+            number_of_bits = 0
         else:
             mask = int(default, 2)
             mask >>= lowest_set_bit(mask)
@@ -497,12 +499,16 @@ class Compiler(object):
             return
 
         if default.startswith('0b'):
-            default = hex(int(default, 2))
-
-        if default.startswith('0x'):
+            default = default[2:]
+            if len(default) % 8 != 0:
+                default += '0' * (-len(default) % 8)
+            member['default'] = binascii.unhexlify(
+                hex(int('11111111' + default, 2))[4:]
+            )
+        elif default.startswith('0x'):
             default = default[2:]
             if len(default) % 2 == 1:
-                default = '0' + default
+                default += '0'
             member['default'] = binascii.unhexlify(default)
 
     def pre_process_parameterization_step_1(self, types, module_name):

--- a/tests/test_der.py
+++ b/tests/test_der.py
@@ -107,6 +107,11 @@ class Asn1ToolsDerTest(Asn1ToolsBaseTest):
             "  a A DEFAULT '00'B, "
             "  b B DEFAULT '00'B "
             "} "
+            "E ::= SEQUENCE { "
+            "  a A DEFAULT ''B, "
+            "  b A DEFAULT ''H, "
+            "  c A DEFAULT '005'H "
+            "} "
             "END",
             'der')
 
@@ -126,6 +131,8 @@ class Asn1ToolsDerTest(Asn1ToolsBaseTest):
              b'\x30\x00'),
             ('D',
              {'a': (b'\x00', 2), 'b': (b'\x00', 2)},
+             b'\x30\x00'),
+            ('E', {'a': (b'', 0), 'b': (b'', 0), 'c': (b'\x00\x50', 12)},
              b'\x30\x00')
         ]
 
@@ -147,7 +154,9 @@ class Asn1ToolsDerTest(Asn1ToolsBaseTest):
             ('D',
              {'a': (b'\x00', 3), 'b': (b'\x00', 3)},
              b'\x30\x04\x80\x02\x05\x00',
-             {'a': (b'\x00', 3), 'b': (b'\x00', 2)})
+             {'a': (b'\x00', 3), 'b': (b'\x00', 2)}),
+            ('E', {}, b'\x30\x00',
+             {'a': (b'', 0), 'b': (b'', 0), 'c': (b'\x00\x50', 12)})
         ]
 
         for type_name, decoded_1, encoded, decoded_2 in datas:
@@ -159,14 +168,21 @@ class Asn1ToolsDerTest(Asn1ToolsBaseTest):
             "Foo DEFINITIONS AUTOMATIC TAGS ::= "
             "BEGIN "
             "A ::= SEQUENCE { "
-            "  b OCTET STRING DEFAULT '011'B, "
-            "  c OCTET STRING DEFAULT '60'H "
+            "  a OCTET STRING DEFAULT '00000000011'B, "
+            "  b OCTET STRING DEFAULT '00060'H "
+            "} "
+            "B ::= SEQUENCE { "
+            "  a OCTET STRING DEFAULT ''B, "
+            "  b OCTET STRING DEFAULT ''H "
             "} "
             "END",
             'der')
 
         datas = [
-            ('A', {'b': b'\xcc', 'c': b'\xdd'}, b'\x30\x06\x80\x01\xcc\x81\x01\xdd'),
+            ('A', {'a': b'\x00\x60', 'b': b'\x00\x06\x00'}, b'\x30\x00'),
+            ('A', {'a': b'\xcc', 'b': b'\xdd'},
+             b'\x30\x06\x80\x01\xcc\x81\x01\xdd'),
+            ('B', {'a': b'', 'b': b''}, b'\x30\x00')
         ]
 
         for type_name, decoded, encoded in datas:
@@ -174,8 +190,10 @@ class Asn1ToolsDerTest(Asn1ToolsBaseTest):
 
         # Default value is not encoded, but part of decoded.
         datas = [
-            ('A', {}, b'\x30\x00', {'b': b'\x03', 'c': b'\x60'}),
-            ('A', {'b': b'\xcc'}, b'\x30\x03\x80\x01\xcc', {'b': b'\xcc', 'c': b'\x60'}),
+            ('A', {}, b'\x30\x00', {'a': b'\x00\x60', 'b': b'\x00\x06\x00'}),
+            ('A', {'a': b'\xcc'}, b'\x30\x03\x80\x01\xcc',
+             {'a': b'\xcc', 'b': b'\x00\x06\x00'}),
+            ('B', {}, b'\x30\x00', {'a': b'', 'b': b''})
         ]
 
         for type_name, decoded_1, encoded, decoded_2 in datas:


### PR DESCRIPTION
- Allow `''B` as default value for `BIT STRING` and `OCTET STRING`
- Properly right pad and preserve leading zeros in `OCTET STRING` default values