### PR TITLE
Support named members decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ gmon.out
 Cargo.lock
 /rust_source.rs
 /*.o
+.idea/
+venv/

--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -25,7 +25,7 @@ from . import generalized_time_from_datetime
 from . import add_error_location
 from .compiler import enum_values_as_dict
 from .compiler import clean_bit_string_value
-
+from .compiler import named_numbers_as_dict
 
 class Class(object):
     UNIVERSAL        = 0x00
@@ -803,10 +803,13 @@ class Boolean(Type):
 
 class Integer(Type):
 
-    def __init__(self, name):
+    def __init__(self, name, named_members=None):
         super(Integer, self).__init__(name,
                                       'INTEGER',
                                       Tag.INTEGER)
+        self.named_members = named_members
+        if named_members is not None:
+            self.named_members = named_numbers_as_dict(named_members)
 
     @add_error_location
     def encode(self, data, encoded):
@@ -819,8 +822,10 @@ class Integer(Type):
 
         length, offset = decode_length_definite(data, offset)
         end_offset = offset + length
-
-        return decode_signed_integer(data[offset:end_offset]), end_offset
+        decoded = decode_signed_integer(data[offset:end_offset])
+        if self.named_members:
+            decoded = self.named_members.get(decoded) or decoded
+        return decoded, end_offset
 
     def __repr__(self):
         return 'Integer({})'.format(self.name)
@@ -871,12 +876,20 @@ class Null(Type):
 
 class BitString(PrimitiveOrConstructedType):
 
-    def __init__(self, name, has_named_bits):
+    def __init__(self, name, has_named_bits, named_members):
         super(BitString, self).__init__(name,
                                         'BIT STRING',
                                         Tag.BIT_STRING,
                                         self)
         self.has_named_bits = has_named_bits
+        self.named_members = named_members
+        if has_named_bits and self.named_members:
+            self.named_members = enum_values_as_dict(self.named_members)
+            # ensure no gap between named bits
+            number_of_named_bits = len(self.named_members)
+            maximum_number_in_named_bits = max([int(key) for key in self.named_members.keys()]) + 1
+            if maximum_number_in_named_bits > number_of_named_bits:
+                self.named_members = None
 
     def is_default(self, value):
         if self.default is None:
@@ -886,7 +899,6 @@ class BitString(PrimitiveOrConstructedType):
                                              self.has_named_bits)
         clean_default = clean_bit_string_value(self.default,
                                                self.has_named_bits)
-
         return clean_value == clean_default
 
     @add_error_location
@@ -909,12 +921,42 @@ class BitString(PrimitiveOrConstructedType):
         encoded.append(number_of_unused_bits)
         encoded.extend(data)
 
+    def get_string_list_representation(self, bytes_array, bits_length):
+        number_of_named_bits = len(self.named_members)
+
+        # convert bytes_array into bit string
+        bit_string = ''.join(["{:08b}".format(byte) for byte in bytes_array])[:bits_length]
+        current_bit_string_length = len(bit_string)
+
+        if current_bit_string_length < number_of_named_bits:
+            # insert zeros to left
+            bit_string = bit_string.rjust(number_of_named_bits, '0')
+        elif current_bit_string_length > number_of_named_bits:
+            extra_bits = bit_string[:current_bit_string_length - number_of_named_bits]
+            is_extra_bits_all_zero = True
+            for bit in extra_bits:
+                is_extra_bits_all_zero = is_extra_bits_all_zero and bit == '0'
+            if is_extra_bits_all_zero:
+                # clean extra bits
+                bit_string = bit_string[current_bit_string_length - number_of_named_bits:]
+            else:
+                return None
+
+        current_bit_string_length = len(bit_string)
+        string_list = []
+        for key, val in self.named_members.items():
+            if bit_string[current_bit_string_length - int(key) - 1] == '1':
+                string_list.append(val)
+        return string_list
+
     def decode_primitive_contents(self, data, offset, length):
         length -= 1
         number_of_bits = 8 * length - data[offset]
         offset += 1
-
-        return (data[offset:offset + length], number_of_bits)
+        decoded = data[offset:offset + length]
+        if self.has_named_bits and self.named_members:
+            decoded = self.get_string_list_representation(decoded, number_of_bits) or decoded
+        return decoded, number_of_bits
 
     def decode_constructed_segments(self, segments):
         decoded = bytearray()
@@ -923,8 +965,10 @@ class BitString(PrimitiveOrConstructedType):
         for data, length in segments:
             decoded.extend(data)
             number_of_bits += length
-
-        return (bytes(decoded), number_of_bits)
+        decoded = bytes(decoded)
+        if self.has_named_bits and self.named_members:
+            decoded = self.get_string_list_representation(decoded, number_of_bits) or decoded
+        return decoded, number_of_bits
 
     def __repr__(self):
         return 'BitString({})'.format(self.name)
@@ -1606,7 +1650,8 @@ class Compiler(compiler.Compiler):
                 *self.compile_members(type_descriptor['members'],
                                       module_name))
         elif type_name == 'INTEGER':
-            compiled = Integer(name)
+            named_members = type_descriptor.get('named-numbers') if self.named_members else None
+            compiled = Integer(name, named_members)
         elif type_name == 'REAL':
             compiled = Real(name)
         elif type_name == 'ENUMERATED':
@@ -1652,7 +1697,8 @@ class Compiler(compiler.Compiler):
             compiled = DateTime(name)
         elif type_name == 'BIT STRING':
             has_named_bits = ('named-bits' in type_descriptor)
-            compiled = BitString(name, has_named_bits)
+            named_members = type_descriptor.get('named-bits') if self.named_members else None
+            compiled = BitString(name, has_named_bits, named_members)
         elif type_name == 'ANY':
             compiled = Any(name)
         elif type_name == 'ANY DEFINED BY':
@@ -1764,8 +1810,8 @@ class Compiler(compiler.Compiler):
             additions.append(compiled_member)
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()
 
 
 def decode_length(data):

--- a/asn1tools/codecs/compiler.py
+++ b/asn1tools/codecs/compiler.py
@@ -183,13 +183,14 @@ class CompiledOpenTypes(CompiledType):
 
 class Compiler(object):
 
-    def __init__(self, specification, numeric_enums=False):
+    def __init__(self, specification, numeric_enums=False, named_members=False):
         self._specification = specification
         self._numeric_enums = numeric_enums
         self._types_backtrace = []
         self.recursive_types = []
         self.compiled = {}
         self.current_type_descriptor = None
+        self.named_members = named_members
 
     def types_backtrace_push(self, type_name):
         self._types_backtrace.append(type_name)
@@ -1178,6 +1179,12 @@ def enum_values_as_dict(values):
         if value != EXTENSION_MARKER
     }
 
+
+def named_numbers_as_dict(values):
+    return {
+        val: key
+        for key, val in values.items()
+    }
 
 def enum_values_split(values):
     if EXTENSION_MARKER in values:

--- a/asn1tools/codecs/constraints_checker.py
+++ b/asn1tools/codecs/constraints_checker.py
@@ -457,5 +457,5 @@ class Compiler(compiler.Compiler):
         return ''.join(sorted(value))
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()

--- a/asn1tools/codecs/der.py
+++ b/asn1tools/codecs/der.py
@@ -135,7 +135,6 @@ class Integer(Type):
     def _decode(self, data, offset):
         length, offset = decode_length_definite(data, offset)
         end_offset = offset + length
-
         return decode_signed_integer(data[offset:end_offset]), end_offset
 
     def __repr__(self):
@@ -459,5 +458,5 @@ class Compiler(ber.Compiler):
         return compiled
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()

--- a/asn1tools/codecs/gser.py
+++ b/asn1tools/codecs/gser.py
@@ -547,7 +547,7 @@ class Compiler(compiler.Compiler):
                 module_name)
             compiled = Choice(name, members)
         elif type_name == 'INTEGER':
-            compiled = Integer(name)
+                compiled = Integer(name)
         elif type_name == 'REAL':
             compiled = Real(name)
         elif type_name == 'ENUMERATED':
@@ -620,8 +620,8 @@ class Compiler(compiler.Compiler):
         return compiled
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()
 
 
 def decode_length(_data):

--- a/asn1tools/codecs/jer.py
+++ b/asn1tools/codecs/jer.py
@@ -660,8 +660,8 @@ class Compiler(compiler.Compiler):
         return compiled
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()
 
 
 def decode_length(_data):

--- a/asn1tools/codecs/oer.py
+++ b/asn1tools/codecs/oer.py
@@ -1502,8 +1502,8 @@ class Compiler(compiler.Compiler):
             additions.append(compiled_member)
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()
 
 
 def decode_length(_data):

--- a/asn1tools/codecs/per.py
+++ b/asn1tools/codecs/per.py
@@ -2287,8 +2287,8 @@ class Compiler(compiler.Compiler):
         return PermittedAlphabet(encode_map, decode_map)
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()
 
 
 def decode_length(_data):

--- a/asn1tools/codecs/type_checker.py
+++ b/asn1tools/codecs/type_checker.py
@@ -377,5 +377,5 @@ class Compiler(compiler.Compiler):
         return compiled
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()

--- a/asn1tools/codecs/uper.py
+++ b/asn1tools/codecs/uper.py
@@ -637,8 +637,8 @@ class Compiler(per.Compiler):
         return compiled
 
 
-def compile_dict(specification, numeric_enums=False):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums=False, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()
 
 
 def decode_length(_data):

--- a/asn1tools/codecs/xer.py
+++ b/asn1tools/codecs/xer.py
@@ -801,8 +801,8 @@ class Compiler(compiler.Compiler):
         return compiled
 
 
-def compile_dict(specification, numeric_enums):
-    return Compiler(specification, numeric_enums).process()
+def compile_dict(specification, numeric_enums, named_members=False):
+    return Compiler(specification, numeric_enums, named_members).process()
 
 
 def decode_length(_data):

--- a/asn1tools/compiler.py
+++ b/asn1tools/compiler.py
@@ -243,7 +243,8 @@ def _compile_files_cache(filenames,
                          any_defined_by_choices,
                          encoding,
                          cache_dir,
-                         numeric_enums):
+                         numeric_enums,
+                         named_members=False):
     key = [codec.encode('ascii')]
 
     if isinstance(filenames, str):
@@ -262,7 +263,8 @@ def _compile_files_cache(filenames,
         compiled = compile_dict(parse_files(filenames, encoding),
                                 codec,
                                 any_defined_by_choices,
-                                numeric_enums)
+                                numeric_enums,
+                                named_members)
         cache[key] = compiled
 
         return compiled
@@ -271,7 +273,8 @@ def _compile_files_cache(filenames,
 def compile_dict(specification,
                  codec='ber',
                  any_defined_by_choices=None,
-                 numeric_enums=False):
+                 numeric_enums=False,
+                 named_members=False):
     """Compile given ASN.1 specification dictionary and return a
     :class:`~asn1tools.compiler.Specification` object that can be used
     to encode and decode data structures with given codec
@@ -280,6 +283,9 @@ def compile_dict(specification,
 
     Give `numeric_enums` as ``True`` for numeric enumeration values
     instead of strings.
+
+    Give `named_members` as ``True`` for string values of named numbers
+    instead of integers.
 
     >>> foo = asn1tools.compile_dict(asn1tools.parse_files('foo.asn'))
 
@@ -306,18 +312,22 @@ def compile_dict(specification,
                                         any_defined_by_choices)
 
     return Specification(codec.compile_dict(specification,
-                                            numeric_enums),
+                                            numeric_enums,
+                                            named_members),
                          codec.decode_length,
                          type_checker.compile_dict(specification,
-                                                   numeric_enums),
+                                                   numeric_enums,
+                                                   named_members),
                          constraints_checker.compile_dict(specification,
-                                                          numeric_enums))
+                                                          numeric_enums,
+                                                          named_members))
 
 
 def compile_string(string,
                    codec='ber',
                    any_defined_by_choices=None,
-                   numeric_enums=False):
+                   numeric_enums=False,
+                   named_members=False):
     """Compile given ASN.1 specification string and return a
     :class:`~asn1tools.compiler.Specification` object that can be used
     to encode and decode data structures with given codec
@@ -327,6 +337,9 @@ def compile_string(string,
     Give `numeric_enums` as ``True`` for numeric enumeration values
     instead of strings.
 
+    Give `named_members` as ``True`` for string values of named numbers
+    instead of integers.
+
     >>> with open('foo.asn') as fin:
     ...     foo = asn1tools.compile_string(fin.read())
 
@@ -335,7 +348,8 @@ def compile_string(string,
     return compile_dict(parse_string(string),
                         codec,
                         any_defined_by_choices,
-                        numeric_enums)
+                        numeric_enums,
+                        named_members)
 
 
 def compile_files(filenames,
@@ -343,7 +357,8 @@ def compile_files(filenames,
                   any_defined_by_choices=None,
                   encoding='utf-8',
                   cache_dir=None,
-                  numeric_enums=False):
+                  numeric_enums=False,
+                  named_members=False):
     """Compile given ASN.1 specification file(s) and return a
     :class:`~asn1tools.compiler.Specification` object that can be used
     to encode and decode data structures with given codec
@@ -364,6 +379,9 @@ def compile_files(filenames,
     Give `numeric_enums` as ``True`` for numeric enumeration values
     instead of strings.
 
+    Give `named_members` as ``True`` for string values of named numbers
+    instead of integers.
+
     >>> foo = asn1tools.compile_files('foo.asn')
 
     Give `cache_dir` as a string to use a cache.
@@ -376,14 +394,16 @@ def compile_files(filenames,
         return compile_dict(parse_files(filenames, encoding),
                             codec,
                             any_defined_by_choices,
-                            numeric_enums)
+                            numeric_enums,
+                            named_members)
     else:
         return _compile_files_cache(filenames,
                                     codec,
                                     any_defined_by_choices,
                                     encoding,
                                     cache_dir,
-                                    numeric_enums)
+                                    numeric_enums,
+                                    named_members)
 
 
 def pre_process_dict(specification):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,6 +46,15 @@ class Asn1ToolsBaseTest(unittest.TestCase):
             print('Expected:', decoded_message)
             raise
 
+    def assert_encode_decode_named_member(self,
+                             specification,
+                             type_name,
+                             decoded_message,
+                             decoded_name,
+                             encoded_message):
+        self.assertEqual(encoded_message, specification.encode(type_name, decoded_message))
+        self.assertEqual(decoded_name, specification.decode(type_name, encoded_message))
+
     def assert_encode_decode_string(self,
                                     specification,
                                     type_name,


### PR DESCRIPTION
According to  ASN.1 specification (ITU-T X.680), 
chapters 19 (Notation for integer type) and 22 (Notation for bitstring type),
such types can be named and we would like to support presenting these names in the decoding output.
This branch is made as a prototype that show how we would support this feature.
The prototype considers .ber format at the moment, if changes are fine we shall continue
 implementing needed changes to support this feature for the other formats.  