### PR TITLE
Pad odd-length octet string with 0

### DIFF
--- a/asn1tools/codecs/xer.py
+++ b/asn1tools/codecs/xer.py
@@ -295,6 +295,8 @@ class OctetString(Type):
         if element.text is None:
             return b''
         else:
+            if len(element.text) % 2:
+                return binascii.unhexlify(element.text.zfill(len(element.text)+1))
             return binascii.unhexlify(element.text)
 
 

--- a/tests/test_xer.py
+++ b/tests/test_xer.py
@@ -90,11 +90,14 @@ class Asn1ToolsXerTest(Asn1ToolsBaseTest):
 
         datas = [
             ('A',         b'', b'<A />'),
+            ('A', b'\x01\x23', b'<A>0123</A>'),
             ('A', b'\x40\x80', b'<A>4080</A>')
         ]
 
         for type_name, decoded, encoded in datas:
             self.assert_encode_decode_string(foo, type_name, decoded, encoded)
+
+        self.assertEqual(b'\x01\x23', foo.decode('A', b'<A>123</A>'))
 
     def test_object_identifier(self):
         foo = asn1tools.compile_string(


### PR DESCRIPTION
This padding isn't, strictly speaking, specified by the XER, but it is a
good idea to be able to accept such input.

Fixes: eerimoq/asn1tools#136