### PR TITLE
Allow {name: value} for CHOICE data.

### DIFF
--- a/asn1tools/codecs/ber.py
+++ b/asn1tools/codecs/ber.py
@@ -14,6 +14,7 @@ from . import EncodeError
 from . import DecodeError
 from . import format_or
 from . import compiler
+from . import normalize
 from . import utc_time_to_datetime
 from . import utc_time_from_datetime
 from . import generalized_time_to_datetime
@@ -1189,6 +1190,7 @@ class Choice(Type):
         return format_or(sorted([member.name for member in self.members]))
 
     def encode(self, data, encoded, values=None):
+        data = normalize.choice(data)
         try:
             member = self.name_to_member[data[0]]
         except KeyError:

--- a/asn1tools/codecs/constraints_checker.py
+++ b/asn1tools/codecs/constraints_checker.py
@@ -8,6 +8,7 @@ from copy import copy
 from . import ConstraintsError, ErrorWithLocation
 from . import compiler
 from . import format_or
+from . import normalize
 from .permitted_alphabet import NUMERIC_STRING
 from .permitted_alphabet import PRINTABLE_STRING
 from .permitted_alphabet import IA5_STRING
@@ -255,6 +256,7 @@ class Choice(Type):
         return format_or(sorted(self.name_to_member))
 
     def encode(self, data):
+        data = normalize.choice(data)
         value = data[0]
 
         if value in self.name_to_member:

--- a/asn1tools/codecs/gser.py
+++ b/asn1tools/codecs/gser.py
@@ -15,6 +15,7 @@ from . import compiler
 from . import format_or
 from . import utc_time_from_datetime
 from . import generalized_time_from_datetime
+from . import normalize
 from .compiler import enum_values_as_dict
 
 
@@ -234,6 +235,7 @@ class Choice(Type):
         return format_or(sorted([member.name for member in self.members]))
 
     def encode(self, data, separator, indent):
+        data = normalize.choice(data)
         try:
             member = self.name_to_member[data[0]]
         except KeyError:

--- a/asn1tools/codecs/jer.py
+++ b/asn1tools/codecs/jer.py
@@ -19,6 +19,7 @@ from . import utc_time_from_datetime
 from . import generalized_time_to_datetime
 from . import generalized_time_from_datetime
 from .compiler import enum_values_as_dict
+from . import normalize
 
 
 class Type(BaseType):
@@ -343,6 +344,7 @@ class Choice(Type):
         return format_or(sorted([member.name for member in self.members]))
 
     def encode(self, data):
+        data = normalize.choice(data)
         try:
             member = self.name_to_member[data[0]]
         except KeyError:

--- a/asn1tools/codecs/normalize.py
+++ b/asn1tools/codecs/normalize.py
@@ -1,0 +1,11 @@
+def choice(data):
+    """Choices should be represented as a tuple of (name, value).  Some parsers
+    that aren't aware of ASN.1 parse things that look like choices into a dict
+    with a single entry: {name: value}. Convert those into the tuple, to
+    accommodate more parsers."""
+    if isinstance(data, dict) and len(data) == 1:
+        key = data.keys().__iter__().__next__()
+        if isinstance(key, str):
+            return (key, data[key])
+
+    return data

--- a/asn1tools/codecs/oer.py
+++ b/asn1tools/codecs/oer.py
@@ -15,6 +15,7 @@ from . import DecodeError
 from . import OutOfDataError
 from . import format_or
 from . import compiler
+from . import normalize
 from . import utc_time_to_datetime
 from . import utc_time_from_datetime
 from . import generalized_time_to_datetime
@@ -950,6 +951,7 @@ class Choice(Type):
         return format_or(sorted([member.name for member in self.members]))
 
     def encode(self, data, encoder):
+        data = normalize.choice(data)
         name = data[0]
 
         if name in self.name_to_root_member:

--- a/asn1tools/codecs/per.py
+++ b/asn1tools/codecs/per.py
@@ -15,6 +15,7 @@ from . import DecodeError
 from . import OutOfDataError
 from . import compiler
 from . import format_or
+from . import normalize
 from . import restricted_utc_time_to_datetime
 from . import restricted_utc_time_from_datetime
 from . import restricted_generalized_time_to_datetime
@@ -1553,6 +1554,7 @@ class Choice(Type):
         return format_or(sorted([member.name for member in members]))
 
     def encode(self, data, encoder):
+        data = normalize.choice(data)
         if self.additions_index_to_member is not None:
             if data[0] in self.root_name_to_index:
                 encoder.append_bit(0)

--- a/asn1tools/codecs/type_checker.py
+++ b/asn1tools/codecs/type_checker.py
@@ -6,9 +6,12 @@ import sys
 import datetime
 from copy import copy
 
+from numpy import isin
+
 from . import EncodeError, ErrorWithLocation
 from . import compiler
 from . import format_or
+from . import normalize
 
 
 STRING_TYPES = [
@@ -217,6 +220,7 @@ class Choice(Type):
         return format_or(sorted([member.name for member in self.members]))
 
     def encode(self, data):
+        data = normalize.choice(data)
         if sys.version_info[0] > 2:
             if (not isinstance(data, tuple)
                 or len(data) != 2

--- a/asn1tools/codecs/xer.py
+++ b/asn1tools/codecs/xer.py
@@ -14,6 +14,7 @@ from . import EncodeError
 from . import DecodeError
 from . import compiler
 from . import format_or
+from . import normalize
 from . import utc_time_to_datetime
 from . import utc_time_from_datetime
 from . import generalized_time_to_datetime
@@ -430,6 +431,7 @@ class Choice(Type):
         return format_or(sorted([member.name for member in self.members]))
 
     def encode(self, data):
+        data = normalize.choice(data)
         try:
             member = self.name_to_member[data[0]]
         except KeyError:

--- a/tests/test_type_checker.py
+++ b/tests/test_type_checker.py
@@ -133,8 +133,14 @@ class Asn1ToolsEncodeTypeCheckerTest(unittest.TestCase):
     def test_choice(self):
         self.assert_good_bad('CHOICE { a NULL }',
                              'A: Expected data of type tuple(str, object)',
-                             good_datas=[('a', None)],
-                             bad_datas=[(1, None), {'a': 1}, None])
+                             good_datas=[('a', None), {'a': None}],
+                             bad_datas=[(1, None), None])
+
+        self.assert_good_bad('CHOICE { a NULL }',
+                             'A.a: Expected None',
+                             good_datas=[],
+                             bad_datas=[{'a': 1}],
+                             bad_datas_strings=["1"])
 
         self.assert_good_bad('CHOICE { a CHOICE { b CHOICE { c NULL } } }',
                              'A.a.b: Expected data of type tuple(str, object)',


### PR DESCRIPTION
Previously only (name, value) was allowed. With this small change,
parsing formats that are not aware of the ASN.1 schema becomes trivial.

For instance we can now parse a JSON5 file and feed it to the encoder.
That means that people writing files by hand can use JSON5, which is
much more pleasant for a human than JER or (arguably) XER.  The output
of asn1vnparser can also be used, so people can use a subset of the
ASN.1 value notation.

There are probably still schemas where parsing without knowledge of the
schema doesn't work, but this catches a very common case where the tools
now become easier to use.