### PR TITLE
Prevent escaping in xer and jer output

### DIFF
--- a/asn1tools/codecs/jer.py
+++ b/asn1tools/codecs/jer.py
@@ -512,9 +512,9 @@ class CompiledType(compiler.CompiledType):
             raise e
 
         if indent is None:
-            string = json.dumps(dictionary, separators=(',', ':'))
+            string = json.dumps(dictionary, ensure_ascii=False, separators=(',', ':'))
         else:
-            string = json.dumps(dictionary, indent=indent)
+            string = json.dumps(dictionary, ensure_ascii=False, indent=indent)
 
         return string.encode('utf-8')
 

--- a/asn1tools/codecs/xer.py
+++ b/asn1tools/codecs/xer.py
@@ -662,7 +662,7 @@ class CompiledType(compiler.CompiledType):
         if indent is not None:
             indent_xml(element, indent * " ")
 
-        return ElementTree.tostring(element)
+        return ElementTree.tostring(element, encoding='utf-8')
 
     def decode(self, data):
         element = ElementTree.fromstring(data.decode('utf-8'))

--- a/tests/test_xer.py
+++ b/tests/test_xer.py
@@ -328,8 +328,8 @@ class Asn1ToolsXerTest(Asn1ToolsBaseTest):
         datas = [
             ('A',         u'', b'<A />'),
             ('A',      u'bar', b'<A>bar</A>'),
-            ('A', u'a\u1010c', b'<A>a&#4112;c</A>'),
-            ('A',    u'f → ∝', b'<A>f &#8594; &#8733;</A>')
+            ('A', u'a\u1010c', b'<A>a\xe1\x80\x90c</A>'),
+            ('A',    u'f → ∝', b'<A>f \xe2\x86\x92 \xe2\x88\x9d</A>'),
         ]
 
         for type_name, decoded, encoded in datas:


### PR DESCRIPTION
Currently the JER and XER encoder escapes non-ascii characters.
ISO/IEC 8825-4:2015 clause 8.1.3 and ISO/IEC 8825-8:2015 clause 7.6.2 demand that both outputs should use UTF-8.

Escaping seems to be allowed for XER, but is forbidden in CXER.
Escaping seems to be allowed for JER.
So, this is probably not a bug.

In my eyes, using the escaping mechanism makes no sense here and leads to less readable output (readability for a human is one of the key features of these encodings).
This PR prevents this escaping mechanism.

If for any reason the current behaviour is beneficial, I suggest adding a further parameter (similar to indent) to control the escaping behaviour.