### PR TITLE
Added _ to permitted ASCII alphabet in PrintableStrings

### DIFF
--- a/asn1tools/codecs/permitted_alphabet.py
+++ b/asn1tools/codecs/permitted_alphabet.py
@@ -15,7 +15,7 @@ NUMERIC_STRING = ' 0123456789'
 PRINTABLE_STRING = (string.ascii_uppercase
                     + string.ascii_lowercase
                     + string.digits
-                    + " '()+,-./:=?")
+                    + " '()+,-./:=_?")
 
 IA5_STRING = ''.join([chr(v) for v in range(128)])
 


### PR DESCRIPTION
This fixes errors with printable strings containing underscores (_). This is, more concretely, useful for 5G/O-RAN telemetry in ASN.1 format, where different printable strings include underscores.