### PR TITLE
fix two unbounded-loop hangs

### DIFF
--- a/asn1tools/codecs/compiler.py
+++ b/asn1tools/codecs/compiler.py
@@ -695,8 +695,14 @@ class Compiler(object):
 
         """
 
+        seen = set()
         try:
             while True:
+                if type_name in seen:
+                    raise CompileError(
+                        "Circular type reference '{}' in module '{}'.".format(
+                            type_name, module_name))
+                seen.add(type_name)
                 if is_object_class_type_name(type_name):
                     type_name, module_name = self.lookup_object_class_type_name(
                         type_name,
@@ -714,8 +720,14 @@ class Compiler(object):
     def resolve_type_descriptor(self, type_descriptor, module_name):
         type_name = type_descriptor['type']
 
+        seen = set()
         try:
             while True:
+                if type_name in seen:
+                    raise CompileError(
+                        "Circular type reference '{}' in module '{}'.".format(
+                            type_name, module_name))
+                seen.add(type_name)
                 if is_object_class_type_name(type_name):
                     type_name, module_name = self.lookup_object_class_type_name(
                         type_name,

--- a/asn1tools/codecs/der.py
+++ b/asn1tools/codecs/der.py
@@ -9,6 +9,7 @@ from . import restricted_generalized_time_to_datetime
 from . import restricted_generalized_time_from_datetime
 from .compiler import clean_bit_string_value
 from .ber import Class, DecodeTagError, StandardEncodeMixin
+from .ber import check_decode_error
 from .ber import Encoding
 from .ber import Tag
 from .ber import encode_length_definite
@@ -90,6 +91,7 @@ class ArrayType(StandardEncodeMixin, Type):
 
         while (offset - start_offset) < length:
             decoded_element, offset = self.element_type.decode(data, offset)
+            check_decode_error(self.element_type, decoded_element, data, offset)
             decoded.append(decoded_element)
 
         return decoded, offset

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -224,6 +224,25 @@ class Asn1ToolsCompileTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Value 'missing-value' not found in module 'A'.")
 
+    def test_circular_tagged_type_self_reference(self):
+        """Test that a self-referencing tagged type does not hang the compiler.
+
+        Without cycle detection in resolve_type_name, this would loop forever.
+
+        """
+        asn1tools.compile_string(
+            'A DEFINITIONS ::= BEGIN A ::= [0] A END')
+
+    def test_circular_tagged_types(self):
+        """Test that two tagged types referencing each other do not hang.
+
+        Without cycle detection in resolve_type_name and
+        resolve_type_descriptor, this would loop forever.
+
+        """
+        asn1tools.compile_string(
+            'A DEFINITIONS ::= BEGIN A ::= [0] B B ::= [1] A END')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_der.py
+++ b/tests/test_der.py
@@ -10,6 +10,7 @@ from .utils import Asn1ToolsBaseTest
 import asn1tools
 from asn1tools.codecs import restricted_utc_time_to_datetime as ut2dt
 from asn1tools.codecs import restricted_generalized_time_to_datetime as gt2dt
+from asn1tools.codecs.ber import DecodeTagError
 from asn1tools.compat import timezone
 from asn1tools.compat import timedelta
 
@@ -582,6 +583,46 @@ class Asn1ToolsDerTest(Asn1ToolsBaseTest):
         )
 
         self.assert_encode_decode(rfc5280, 'Certificate', decoded, encoded)
+
+    def test_sequence_of_malformed_element(self):
+        """Test that malformed SEQUENCE OF data raises DecodeTagError.
+
+        Without the check_decode_error call in ArrayType.decode_content,
+        a malformed element would return TAG_MISMATCH without advancing the
+        offset, causing an infinite loop.
+
+        """
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS ::= BEGIN A ::= SEQUENCE OF INTEGER END",
+            'der')
+
+        encoded = foo.encode('A', [1, 2])
+
+        # Corrupt the second element: change its tag from INTEGER (02) to
+        # NULL (05), leaving the length and value intact.
+        malformed = bytearray(encoded)
+        malformed[5] = 0x05
+
+        with self.assertRaises(DecodeTagError):
+            foo.decode('A', bytes(malformed))
+
+    def test_set_of_malformed_element(self):
+        """Test that malformed SET OF data raises DecodeTagError.
+
+        Same as test_sequence_of_malformed_element but for SET OF.
+
+        """
+        foo = asn1tools.compile_string(
+            "Foo DEFINITIONS ::= BEGIN A ::= SET OF INTEGER END",
+            'der')
+
+        encoded = foo.encode('A', [1, 2])
+
+        malformed = bytearray(encoded)
+        malformed[5] = 0x05
+
+        with self.assertRaises(DecodeTagError):
+            foo.decode('A', bytes(malformed))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
PR re-issue using correct master branch

Add cycle detection to resolve_type_name and resolve_type_descriptor in compiler.py so that circular tagged types raise CompileError instead of looping forever.

Add a missing check_decode_error call in ArrayType.decode_content (der.py) so that malformed SEQUENCE OF / SET OF data raises DecodeTagError instead of looping forever.